### PR TITLE
Remove unnecessary check for `quote_state`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -127,17 +127,13 @@ pub(crate) fn quote_context_aware_find(
         read += bytes.len();
 
         if found_last_byte {
-            match quote_state {
-                QuoteState::None => {
-                    if byte_seq_len <= read && &buf[read - byte_seq_len..read] == byte_seq {
-                        debug_assert_eq!(
-                            find_matching_suffix(byte_seq, &buf[read - byte_seq_len..read]),
-                            AlreadyFoundByteSeqCount(byte_seq_len)
-                        );
-                        return (read, QuoteContextAwareFoundState::Found);
-                    }
-                }
-                QuoteState::Single | QuoteState::Double => {}
+            debug_assert_eq!(quote_state, QuoteState::None);
+            if byte_seq_len <= read && &buf[read - byte_seq_len..read] == byte_seq {
+                debug_assert_eq!(
+                    find_matching_suffix(byte_seq, &buf[read - byte_seq_len..read]),
+                    AlreadyFoundByteSeqCount(byte_seq_len)
+                );
+                return (read, QuoteContextAwareFoundState::Found);
             }
         } else {
             debug_assert_eq!(read, buf.len());


### PR DESCRIPTION
`found_last_byte` set to `true` only when `quote_state == None`, so no need to check that again.

(_review with ignore whitespace changes option on_)

I also noticed, that function `quote_context_aware_find` is unnecessary generic: it is called only with `byte_seq = b">"` from library code; other variants (other length and content) are passed only in tests. So it is possible to simplify that function by inlining that parameter, of course, if you do not plan to reuse function in the future.
  
The same is applied to `already_found_byte_seq_count` parameter too, which really used value only `AlreadyFoundByteSeqCount(0)`, and other values supplies only in tests. So it can be completely removed, as like as a second item of `QuoteContextAwareFoundState::NotFound` tuple.