### PR TITLE
fix: avoid out-of-bounds panic scanning truncated comment start

### DIFF
--- a/maybe_xml/src/read.rs
+++ b/maybe_xml/src/read.rs
@@ -450,6 +450,18 @@ mod tests {
         let _ = reader.tokenize(&mut pos);
     }
 
+    #[test]
+    fn no_panic_on_truncated_comment_start() {
+        let reader = Reader::from_str(".<!-");
+        let mut pos = 0;
+        assert_eq!(
+            Some(Ty::Characters(Characters::from_str("."))),
+            reader.tokenize(&mut pos).map(|token| token.ty())
+        );
+        assert_eq!(None, reader.tokenize(&mut pos));
+        assert_eq!(1, pos);
+    }
+
     fn verify_tokenize_all(input: &str, expected: &[Ty<'_>]) {
         verify_tokenize(input, 0, expected, input.len());
     }

--- a/maybe_xml/src/read/scanner.rs
+++ b/maybe_xml/src/read/scanner.rs
@@ -115,7 +115,7 @@ const fn scan_declaration_comment_or_cdata(input: &[u8], pos: usize) -> Option<u
     match input[peek3] {
         b'-' => {
             let peek4 = pos + 3;
-            if input.len() < peek4 {
+            if input.len() <= peek4 {
                 return None;
             }
             match input[peek4] {


### PR DESCRIPTION
Input ending in `<!-` made `scan_declaration_comment_or_cdata` index one byte past the end of the slice because the bounds check used `<` instead of `<=` like every other peek check. Closes #17.